### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/chatbot/processor.py
+++ b/chatbot/processor.py
@@ -8,6 +8,7 @@ from .manager import ChatbotManager
 import urllib3
 from urllib.parse import urlparse
 import re
+import bleach
 import os
 import hashlib
 import time
@@ -177,7 +178,7 @@ class WebPageSecurityManager:
         sanitized_text = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', text)
         
         # Remove potential XSS and script injection attempts
-        sanitized_text = re.sub(r'<script.*?>.*?</script>', '', sanitized_text, flags=re.DOTALL | re.IGNORECASE)
+        sanitized_text = bleach.clean(sanitized_text, tags=[], attributes={}, protocols=[], strip=True)
         sanitized_text = re.sub(r'javascript:', '', sanitized_text, flags=re.IGNORECASE)
         
         # Limit text length

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ streamlit==1.37.0
 tiktoken==0.9.0
 transformers==4.48.0
 urllib3==1.26.17
+
+bleach==6.2.0


### PR DESCRIPTION
Potential fix for [https://github.com/ArhamMirza/Customizable-Chatbot/security/code-scanning/3](https://github.com/ArhamMirza/Customizable-Chatbot/security/code-scanning/3)

To fix the problem, we should replace the custom regular expression used to filter out `<script>` tags with a well-tested HTML sanitization library. This will ensure that all variations of the `<script>` tag are properly handled, reducing the risk of XSS attacks.

The best way to fix the problem without changing existing functionality is to use the `bleach` library, which is a well-known and widely-used HTML sanitization library in Python. We will replace the custom regular expression with a call to `bleach.clean` to remove potentially dangerous content.

We need to:
1. Install the `bleach` library.
2. Import the `bleach` library in the `chatbot/processor.py` file.
3. Replace the custom regular expression used to filter out `<script>` tags with a call to `bleach.clean`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
